### PR TITLE
Dozer -> ModelMapper, because of Dozer compatibility issues with JAVA 8

### DIFF
--- a/Secret-agency-service/pom.xml
+++ b/Secret-agency-service/pom.xml
@@ -22,9 +22,9 @@
 
         <!-- Mapping between entities and DTOs -->
         <dependency>
-            <groupId>net.sf.dozer</groupId>
-            <artifactId>dozer</artifactId>
-            <version>5.5.1</version>
+            <groupId>org.modelmapper</groupId>
+            <artifactId>modelmapper</artifactId>
+            <version>2.3.0</version>
         </dependency>
 
     </dependencies>

--- a/Secret-agency-service/src/main/java/cz/fi/muni/pa165/secretagency/service/BeanMappingService.java
+++ b/Secret-agency-service/src/main/java/cz/fi/muni/pa165/secretagency/service/BeanMappingService.java
@@ -1,6 +1,6 @@
 package cz.fi.muni.pa165.secretagency.service;
 
-import org.dozer.Mapper;
+import org.modelmapper.ModelMapper;
 
 import java.util.Collection;
 import java.util.List;
@@ -14,5 +14,5 @@ public interface BeanMappingService {
     <T> List<T> mapTo(Collection<?> objects, Class<T> mapToClass);
 
     <T> T mapTo(Object u, Class<T> mapToClass);
-    Mapper getMapper();
+    ModelMapper getMapper();
 }

--- a/Secret-agency-service/src/main/java/cz/fi/muni/pa165/secretagency/service/BeanMappingServiceImpl.java
+++ b/Secret-agency-service/src/main/java/cz/fi/muni/pa165/secretagency/service/BeanMappingServiceImpl.java
@@ -1,6 +1,6 @@
 package cz.fi.muni.pa165.secretagency.service;
 
-import org.dozer.Mapper;
+import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -15,22 +15,22 @@ import java.util.List;
 public class BeanMappingServiceImpl implements BeanMappingService {
 
     @Autowired
-    private Mapper dozer;
+    private ModelMapper modelMapper;
 
     public  <T> List<T> mapTo(Collection<?> objects, Class<T> mapToClass) {
         List<T> mappedCollection = new ArrayList<>();
         for (Object object : objects) {
-            mappedCollection.add(dozer.map(object, mapToClass));
+            mappedCollection.add(modelMapper.map(object, mapToClass));
         }
         return mappedCollection;
     }
 
     public  <T> T mapTo(Object u, Class<T> mapToClass)
     {
-        return dozer.map(u,mapToClass);
+        return modelMapper.map(u,mapToClass);
     }
 
-    public Mapper getMapper(){
-        return dozer;
+    public ModelMapper getMapper(){
+        return modelMapper;
     }
 }

--- a/Secret-agency-service/src/main/java/cz/fi/muni/pa165/secretagency/service/config/ServiceConfiguration.java
+++ b/Secret-agency-service/src/main/java/cz/fi/muni/pa165/secretagency/service/config/ServiceConfiguration.java
@@ -2,8 +2,7 @@ package cz.fi.muni.pa165.secretagency.service.config;
 
 import cz.fi.muni.pa165.secretagency.SecretAgencyPersistenceApplicationContext;
 import cz.fi.muni.pa165.secretagency.service.AgentServiceImpl;
-import org.dozer.DozerBeanMapper;
-import org.dozer.Mapper;
+import org.modelmapper.ModelMapper;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -20,8 +19,7 @@ import org.springframework.context.annotation.Import;
 public class ServiceConfiguration {
 
     @Bean
-    public Mapper dozer(){
-        return new DozerBeanMapper();
+    public ModelMapper modelMapper() {
+        return new ModelMapper();
     }
-
 }


### PR DESCRIPTION
Usage of ModelMapper instead of Dozer for entity-DTO mapping. Dozer has compatibility issues with JAVA 8