### PR TITLE
DirtiesContext annotations added for every test class.

### DIFF
--- a/Secret-agency-service/src/main/java/cz/fi/muni/pa165/secretagency/service/facade/ReportFacadeImpl.java
+++ b/Secret-agency-service/src/main/java/cz/fi/muni/pa165/secretagency/service/facade/ReportFacadeImpl.java
@@ -60,11 +60,11 @@ public class ReportFacadeImpl implements ReportFacade {
         Mission mission = missionService.getEntityById(reportDTO.getMissionId());
 
         if (agent == null) {
-            throw new NullPointerException("Agent with selected id was not found");
+            throw new NullPointerException("Agent with id " + reportDTO.getAgentId() + " was not found");
         }
 
         if (mission == null) {
-            throw new NullPointerException("Mission with selected id was not found");
+            throw new NullPointerException("Mission with id " + reportDTO.getMissionId() + "was not found");
         }
 
         Report report = new Report();

--- a/Secret-agency-service/src/test/java/cz/fi/muni/pa165/secretagency/service/AgentServiceTest.java
+++ b/Secret-agency-service/src/test/java/cz/fi/muni/pa165/secretagency/service/AgentServiceTest.java
@@ -11,6 +11,7 @@ import org.hibernate.service.spi.ServiceException;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -30,6 +31,7 @@ import static org.testng.Assert.assertEquals;
  * Time: 4:01 PM
  */
 @ContextConfiguration(classes = ServiceConfiguration.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 public class AgentServiceTest extends AbstractTestNGSpringContextTests {
     @Mock
     private AgentDao agentDao;

--- a/Secret-agency-service/src/test/java/cz/fi/muni/pa165/secretagency/service/MissionServiceTest.java
+++ b/Secret-agency-service/src/test/java/cz/fi/muni/pa165/secretagency/service/MissionServiceTest.java
@@ -8,6 +8,7 @@ import cz.fi.muni.pa165.secretagency.service.exceptions.MissionServiceException;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -28,6 +29,7 @@ import static org.mockito.Mockito.when;
  * Tests for Mission Service
  */
 @ContextConfiguration(classes = ServiceConfiguration.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 public class MissionServiceTest extends AbstractTestNGSpringContextTests {
 
     @Mock

--- a/Secret-agency-service/src/test/java/cz/fi/muni/pa165/secretagency/service/ReportServiceTest.java
+++ b/Secret-agency-service/src/test/java/cz/fi/muni/pa165/secretagency/service/ReportServiceTest.java
@@ -11,6 +11,7 @@ import cz.fi.muni.pa165.secretagency.service.exceptions.ReportServiceException;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -32,6 +33,7 @@ import static org.mockito.Mockito.when;
  * @author Jan Pavlu (487548)
  */
 @ContextConfiguration(classes = ServiceConfiguration.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 public class ReportServiceTest extends AbstractTestNGSpringContextTests {
 
     @Mock

--- a/Secret-agency-service/src/test/java/cz/fi/muni/pa165/secretagency/service/facade/AgentFacadeTest.java
+++ b/Secret-agency-service/src/test/java/cz/fi/muni/pa165/secretagency/service/facade/AgentFacadeTest.java
@@ -14,6 +14,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
 import org.testng.annotations.BeforeMethod;
@@ -34,6 +35,7 @@ import static org.testng.AssertJUnit.assertEquals;
  * Time: 3:57 PM
  */
 @ContextConfiguration(classes = ServiceConfiguration.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 public class AgentFacadeTest extends AbstractTestNGSpringContextTests {
 
     @Spy

--- a/Secret-agency-service/src/test/java/cz/fi/muni/pa165/secretagency/service/facade/ReportFacadeIntegrationTest.java
+++ b/Secret-agency-service/src/test/java/cz/fi/muni/pa165/secretagency/service/facade/ReportFacadeIntegrationTest.java
@@ -108,15 +108,13 @@ public class ReportFacadeIntegrationTest extends AbstractTestNGSpringContextTest
     }
 
     // TESTS
-    //@Test
+    @Test
     public void createReport() {
         ReportCreateDTO reportCreateDTO = new ReportCreateDTO();
         reportCreateDTO.setAgentId(babis.getId());
         reportCreateDTO.setMissionId(transferBabisJrToKrym.getId());
         reportCreateDTO.setMissionResult(MissionResultReportEnum.COMPLETED);
         reportCreateDTO.setText("Make Vodnanske kure great again");
-        // TODO - it fails, when tests are run usin mvn install
-        // when running this test class from the IDE, it works correctly
         Long newReportId = reportFacade.createReport(reportCreateDTO);
 
         ReportDTO newReport = reportFacade.getReportById(newReportId);


### PR DESCRIPTION
This should ensure that after running all test in a test class, the database is set to its original state.