### PR TITLE
Solving circular dependencies - dumb way

### DIFF
--- a/Secret-agency-api/src/main/java/cz/fi/muni/pa165/secretagency/dto/AgentDTO.java
+++ b/Secret-agency-api/src/main/java/cz/fi/muni/pa165/secretagency/dto/AgentDTO.java
@@ -19,9 +19,7 @@ public class AgentDTO {
     private AgentRankEnum rank;
     private String codeName;
     private String passwordHash;
-    private List<MissionDTO> missions = new ArrayList<>();
     private DepartmentDTO department;
-    private List<ReportDTO> reports = new ArrayList<>();
 
     public Long getId() {
         return id;
@@ -71,22 +69,6 @@ public class AgentDTO {
         this.codeName = codeName;
     }
 
-    public List<ReportDTO> getReports() {
-        return reports;
-    }
-
-    public void setReports(List<ReportDTO> reports) {
-        this.reports = reports;
-    }
-
-    public List<MissionDTO> getMissions() {
-        return missions;
-    }
-
-    public void setMissions(List<MissionDTO> missions) {
-        this.missions = missions;
-    }
-
     public DepartmentDTO getDepartment() {
         return department;
     }
@@ -126,9 +108,7 @@ public class AgentDTO {
                 ", rank=" + rank +
                 ", codeName='" + codeName + '\'' +
                 ", passwordHash='" + passwordHash + '\'' +
-                ", missions=" + missions +
                 ", department=" + department +
-                ", reports=" + reports +
                 '}';
     }
 }

--- a/Secret-agency-api/src/main/java/cz/fi/muni/pa165/secretagency/dto/DepartmentDTO.java
+++ b/Secret-agency-api/src/main/java/cz/fi/muni/pa165/secretagency/dto/DepartmentDTO.java
@@ -25,8 +25,6 @@ public class DepartmentDTO {
 
     private DepartmentSpecialization specialization;
 
-    private List<AgentDTO> agents = new ArrayList<>();
-
     public Long getId() { return id; }
     public void setId(Long id) { this.id = id; }
 
@@ -44,9 +42,6 @@ public class DepartmentDTO {
 
     public DepartmentSpecialization getSpecialization() { return specialization; }
     public void setSpecialization(DepartmentSpecialization specialization) { this.specialization = specialization; }
-
-    public List<AgentDTO> getAgents() { return agents; }
-    public void setAgents(List<AgentDTO> agents) { this.agents = agents; }
 
     @Override
     public boolean equals(Object o) {
@@ -74,7 +69,6 @@ public class DepartmentDTO {
                 ", latitude=" + latitude +
                 ", longitude=" + longitude +
                 ", specialization=" + specialization +
-                ", agents=" + agents +
                 '}';
     }
 }

--- a/Secret-agency-api/src/main/java/cz/fi/muni/pa165/secretagency/dto/MissionDTO.java
+++ b/Secret-agency-api/src/main/java/cz/fi/muni/pa165/secretagency/dto/MissionDTO.java
@@ -19,8 +19,6 @@ public class MissionDTO {
     private MissionTypeEnum missionType;
     private LocalDate started;
     private LocalDate ended;
-    private Set<AgentDTO> agents = new HashSet<>();
-    private Set<ReportDTO> reports = new HashSet<>();
 
     public Long getId() {
         return id;
@@ -70,22 +68,6 @@ public class MissionDTO {
         this.ended = ended;
     }
 
-    public Set<AgentDTO> getAgents() {
-        return agents;
-    }
-
-    public void setAgents(Set<AgentDTO> agents) {
-        this.agents = agents;
-    }
-
-    public Set<ReportDTO> getReports() {
-        return reports;
-    }
-
-    public void setReports(Set<ReportDTO> reports) {
-        this.reports = reports;
-    }
-
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -112,8 +94,6 @@ public class MissionDTO {
                 ", missionType=" + missionType +
                 ", started=" + started +
                 ", ended=" + ended +
-                ", agents=" + agents +
-                ", reports=" + reports +
                 '}';
     }
 }

--- a/Secret-agency-persistence/src/main/java/cz/fi/muni/pa165/secretagency/entity/Agent.java
+++ b/Secret-agency-persistence/src/main/java/cz/fi/muni/pa165/secretagency/entity/Agent.java
@@ -52,7 +52,7 @@ public class Agent {
     @NotNull
     private Department department;
 
-    @OneToMany(mappedBy = "agent")
+    @OneToMany(mappedBy = "agent", fetch = FetchType.LAZY)
     private List<Report> reports = new ArrayList<>();
 
     /** Create empty Agent **/

--- a/Secret-agency-persistence/src/main/java/cz/fi/muni/pa165/secretagency/entity/Department.java
+++ b/Secret-agency-persistence/src/main/java/cz/fi/muni/pa165/secretagency/entity/Department.java
@@ -36,7 +36,7 @@ public class Department {
     @Enumerated
     private DepartmentSpecialization specialization;
 
-    @OneToMany(mappedBy = "department")
+    @OneToMany(mappedBy = "department", fetch = FetchType.LAZY)
     private List<Agent> agents = new ArrayList<>();
 
     public Department() {

--- a/Secret-agency-persistence/src/main/java/cz/fi/muni/pa165/secretagency/entity/Mission.java
+++ b/Secret-agency-persistence/src/main/java/cz/fi/muni/pa165/secretagency/entity/Mission.java
@@ -38,7 +38,7 @@ public class Mission {
     @Nullable
     private LocalDate ended;
 
-    @ManyToMany(mappedBy = "missions")
+    @ManyToMany(mappedBy = "missions", fetch = FetchType.LAZY)
     private Set<Agent> agents = new HashSet<>();
 
     @OneToMany(mappedBy = "mission")

--- a/Secret-agency-service/src/main/java/cz/fi/muni/pa165/secretagency/service/BeanMappingServiceImpl.java
+++ b/Secret-agency-service/src/main/java/cz/fi/muni/pa165/secretagency/service/BeanMappingServiceImpl.java
@@ -19,7 +19,7 @@ public class BeanMappingServiceImpl implements BeanMappingService {
     public  <T> List<T> mapTo(Collection<?> objects, Class<T> mapToClass) {
         List<T> mappedCollection = new ArrayList<>();
         for (Object object : objects) {
-            mappedCollection.add(modelMapper.map(object, mapToClass));
+            mappedCollection.add(mapTo(object, mapToClass));
         }
         return mappedCollection;
     }
@@ -28,15 +28,14 @@ public class BeanMappingServiceImpl implements BeanMappingService {
     public <T> Set<T> mapToSet(Collection<?> objects, Class<T> mapToClass) {
         Set<T> mappedSet = new HashSet<>();
         for (Object o : objects) {
-            mappedSet.add(modelMapper.map(objects, mapToClass));
+            mappedSet.add(mapTo(o, mapToClass));
         }
         return mappedSet;
     }
 
     @Override
-    public  <T> T mapTo(Object u, Class<T> mapToClass)
-    {
-        return modelMapper.map(u,mapToClass);
+    public  <T> T mapTo(Object u, Class<T> mapToClass) {
+        return modelMapper.map(u, mapToClass);
     }
 
     public ModelMapper getMapper(){

--- a/Secret-agency-service/src/main/java/cz/fi/muni/pa165/secretagency/service/config/ServiceConfiguration.java
+++ b/Secret-agency-service/src/main/java/cz/fi/muni/pa165/secretagency/service/config/ServiceConfiguration.java
@@ -21,8 +21,7 @@ public class ServiceConfiguration {
     @Bean
     public ModelMapper modelMapper() {
         ModelMapper modelMapper = new ModelMapper();
-        // with loose mapping, mapper is able to map nested classes
-        modelMapper.getConfiguration().setMatchingStrategy(MatchingStrategies.STANDARD);
+        modelMapper.getConfiguration().setMatchingStrategy(MatchingStrategies.STRICT);
         return modelMapper;
     }
 }

--- a/Secret-agency-service/src/test/java/cz/fi/muni/pa165/secretagency/service/BeanMappingServiceTest.java
+++ b/Secret-agency-service/src/test/java/cz/fi/muni/pa165/secretagency/service/BeanMappingServiceTest.java
@@ -108,7 +108,7 @@ public class BeanMappingServiceTest extends AbstractTestNGSpringContextTests
     @Test
     public void mapDepartmentToDepartmentDtoTest() {
         Department department = new Department();
-        department.setId(1l);
+        department.setId(1L);
         department.setCity("london");
         department.setCountry("uk");
         department.setLatitude(2.0);
@@ -118,7 +118,6 @@ public class BeanMappingServiceTest extends AbstractTestNGSpringContextTests
         DepartmentDTO departmentDTO = beanMappingService.mapTo(department, DepartmentDTO.class);
 
         Assert.assertEquals(department.getId(), departmentDTO.getId());
-        Assert.assertEquals(department.getAgents().size(), departmentDTO.getAgents().size());
         Assert.assertEquals(department.getCity(), departmentDTO.getCity());
         Assert.assertEquals(department.getCountry(), departmentDTO.getCountry());
         Assert.assertEquals(department.getLatitude(), departmentDTO.getLatitude());
@@ -129,7 +128,7 @@ public class BeanMappingServiceTest extends AbstractTestNGSpringContextTests
     @Test
     public void mapDepartmentDtoToDepartmentTest() {
         DepartmentDTO departmentDTO = new DepartmentDTO();
-        departmentDTO.setId(1l);
+        departmentDTO.setId(1L);
         departmentDTO.setCity("london");
         departmentDTO.setCountry("uk");
         departmentDTO.setLatitude(2.0);
@@ -139,7 +138,7 @@ public class BeanMappingServiceTest extends AbstractTestNGSpringContextTests
         Department department = beanMappingService.mapTo(departmentDTO, Department.class);
 
         Assert.assertEquals(department.getId(), departmentDTO.getId());
-        Assert.assertEquals(department.getAgents().size(), departmentDTO.getAgents().size());
+
         Assert.assertEquals(department.getCity(), departmentDTO.getCity());
         Assert.assertEquals(department.getCountry(), departmentDTO.getCountry());
         Assert.assertEquals(department.getLatitude(), departmentDTO.getLatitude());
@@ -150,7 +149,7 @@ public class BeanMappingServiceTest extends AbstractTestNGSpringContextTests
    @Test
    public void mapAgentToAgentDtoTest() {
         Agent agent = new Agent();
-        agent.setId(1l);
+        agent.setId(1L);
         agent.setName("bond");
         agent.setLanguages(Collections.singleton(LanguageEnum.EN));
         agent.setCodeName("007");
@@ -170,7 +169,7 @@ public class BeanMappingServiceTest extends AbstractTestNGSpringContextTests
     @Test
     public void mapAgentDtoToAgentTest() {
         AgentDTO agentDTO = new AgentDTO();
-        agentDTO.setId(1l);
+        agentDTO.setId(1L);
         agentDTO.setName("bond");
         agentDTO.setLanguages(Collections.singleton(LanguageEnum.EN));
         agentDTO.setCodeName("007");
@@ -190,7 +189,7 @@ public class BeanMappingServiceTest extends AbstractTestNGSpringContextTests
     @Test
     public void mapReportToReportDtoTest() {
         Report report = new Report();
-        report.setId(42l);
+        report.setId(42L);
         report.setText("report");
         report.setReportStatus(ReportStatus.APPROVED);
         report.setMissionResult(MissionResultReportEnum.COMPLETED);
@@ -208,7 +207,7 @@ public class BeanMappingServiceTest extends AbstractTestNGSpringContextTests
     @Test
     public void mapReportDtoToReportTest() {
         ReportDTO reportDTO = new ReportDTO();
-        reportDTO.setId(42l);
+        reportDTO.setId(42L);
         reportDTO.setText("report");
         reportDTO.setReportStatus(ReportStatus.APPROVED);
         reportDTO.setMissionResult(MissionResultReportEnum.COMPLETED);
@@ -226,7 +225,7 @@ public class BeanMappingServiceTest extends AbstractTestNGSpringContextTests
     @Test
     public void mapMissionToMissionDtoTest() {
         Mission mission = new Mission();
-        mission.setId(142l);
+        mission.setId(142L);
         mission.setLatitude(3.4);
         mission.setLongitude(54.1);
         mission.setStarted(LocalDate.of(2013, 4, 9));
@@ -246,7 +245,7 @@ public class BeanMappingServiceTest extends AbstractTestNGSpringContextTests
     @Test
     public void mapMissionDtoToMissionTest() {
         MissionDTO missionDTO = new MissionDTO();
-        missionDTO.setId(142l);
+        missionDTO.setId(142L);
         missionDTO.setLatitude(3.4);
         missionDTO.setLongitude(54.1);
         missionDTO.setStarted(LocalDate.of(2013, 4, 9));


### PR DESCRIPTION
Při mapování entit na DTO nám došlo k zacyklení, protože na sebe DTO vzájemně odkazují. Nejjednodušším řešením bylo z DTO odstranit atributy odkazující na jiná DTO (stačí u jednoho z DTO, který se vztahu účastní). Odstranil jsem ty atributy, které jsou kolekcí DTO.

Ideálním řešením by asi bylo mapovat atributy, které jsou kolekcí DTO na kolekci ID, ale to by zabralo víc času. 