### PR TITLE
Entity dto mapping improvement

### DIFF
--- a/Secret-agency-api/src/main/java/cz/fi/muni/pa165/secretagency/dto/AgentDTO.java
+++ b/Secret-agency-api/src/main/java/cz/fi/muni/pa165/secretagency/dto/AgentDTO.java
@@ -19,9 +19,9 @@ public class AgentDTO {
     private AgentRankEnum rank;
     private String codeName;
     private String passwordHash;
-    private List<MissionDTO> missions = new ArrayList<>();
     private DepartmentDTO department;
-    private List<ReportDTO> reports = new ArrayList<>();
+    private List<Long> missionIds = new ArrayList<>();
+    private List<Long> reportIds = new ArrayList<>();
 
     public Long getId() {
         return id;
@@ -71,28 +71,28 @@ public class AgentDTO {
         this.codeName = codeName;
     }
 
-    public List<ReportDTO> getReports() {
-        return reports;
-    }
-
-    public void setReports(List<ReportDTO> reports) {
-        this.reports = reports;
-    }
-
-    public List<MissionDTO> getMissions() {
-        return missions;
-    }
-
-    public void setMissions(List<MissionDTO> missions) {
-        this.missions = missions;
-    }
-
     public DepartmentDTO getDepartment() {
         return department;
     }
 
     public void setDepartment(DepartmentDTO department) {
         this.department = department;
+    }
+
+    public List<Long> getMissionIds() {
+        return missionIds;
+    }
+
+    public void setMissionIds(List<Long> missionIds) {
+        this.missionIds = missionIds;
+    }
+
+    public List<Long> getReportIds() {
+        return reportIds;
+    }
+
+    public void setReportIds(List<Long> reportIds) {
+        this.reportIds = reportIds;
     }
 
     public String getPasswordHash() {
@@ -126,9 +126,9 @@ public class AgentDTO {
                 ", rank=" + rank +
                 ", codeName='" + codeName + '\'' +
                 ", passwordHash='" + passwordHash + '\'' +
-                ", missions=" + missions +
                 ", department=" + department +
-                ", reports=" + reports +
+                ", missionIds=" + missionIds +
+                ", reportIds=" + reportIds +
                 '}';
     }
 }

--- a/Secret-agency-api/src/main/java/cz/fi/muni/pa165/secretagency/dto/AgentDTO.java
+++ b/Secret-agency-api/src/main/java/cz/fi/muni/pa165/secretagency/dto/AgentDTO.java
@@ -20,8 +20,8 @@ public class AgentDTO {
     private String codeName;
     private String passwordHash;
     private DepartmentDTO department;
-    private List<Long> missionIds = new ArrayList<>();
-    private List<Long> reportIds = new ArrayList<>();
+    private Set<Long> missionIds = new HashSet<>();
+    private Set<Long> reportIds = new HashSet<>();
 
     public Long getId() {
         return id;
@@ -79,19 +79,19 @@ public class AgentDTO {
         this.department = department;
     }
 
-    public List<Long> getMissionIds() {
+    public Set<Long> getMissionIds() {
         return missionIds;
     }
 
-    public void setMissionIds(List<Long> missionIds) {
+    public void setMissionIds(Set<Long> missionIds) {
         this.missionIds = missionIds;
     }
 
-    public List<Long> getReportIds() {
+    public Set<Long> getReportIds() {
         return reportIds;
     }
 
-    public void setReportIds(List<Long> reportIds) {
+    public void setReportIds(Set<Long> reportIds) {
         this.reportIds = reportIds;
     }
 

--- a/Secret-agency-api/src/main/java/cz/fi/muni/pa165/secretagency/dto/DepartmentDTO.java
+++ b/Secret-agency-api/src/main/java/cz/fi/muni/pa165/secretagency/dto/DepartmentDTO.java
@@ -25,7 +25,7 @@ public class DepartmentDTO {
 
     private DepartmentSpecialization specialization;
 
-    private List<AgentDTO> agents = new ArrayList<>();
+    private List<Long> agentIds = new ArrayList<>();
 
     public Long getId() { return id; }
     public void setId(Long id) { this.id = id; }
@@ -45,8 +45,13 @@ public class DepartmentDTO {
     public DepartmentSpecialization getSpecialization() { return specialization; }
     public void setSpecialization(DepartmentSpecialization specialization) { this.specialization = specialization; }
 
-    public List<AgentDTO> getAgents() { return agents; }
-    public void setAgents(List<AgentDTO> agents) { this.agents = agents; }
+    public List<Long> getAgentIds() {
+        return agentIds;
+    }
+
+    public void setAgentIds(List<Long> agentIds) {
+        this.agentIds = agentIds;
+    }
 
     @Override
     public boolean equals(Object o) {
@@ -74,7 +79,7 @@ public class DepartmentDTO {
                 ", latitude=" + latitude +
                 ", longitude=" + longitude +
                 ", specialization=" + specialization +
-                ", agents=" + agents +
+                ", agentIds=" + agentIds +
                 '}';
     }
 }

--- a/Secret-agency-api/src/main/java/cz/fi/muni/pa165/secretagency/dto/DepartmentDTO.java
+++ b/Secret-agency-api/src/main/java/cz/fi/muni/pa165/secretagency/dto/DepartmentDTO.java
@@ -2,9 +2,7 @@ package cz.fi.muni.pa165.secretagency.dto;
 
 import cz.fi.muni.pa165.secretagency.enums.DepartmentSpecialization;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 
 /**
  * DTO for Department
@@ -25,7 +23,7 @@ public class DepartmentDTO {
 
     private DepartmentSpecialization specialization;
 
-    private List<Long> agentIds = new ArrayList<>();
+    private Set<Long> agentIds = new HashSet<>();
 
     public Long getId() { return id; }
     public void setId(Long id) { this.id = id; }
@@ -45,11 +43,11 @@ public class DepartmentDTO {
     public DepartmentSpecialization getSpecialization() { return specialization; }
     public void setSpecialization(DepartmentSpecialization specialization) { this.specialization = specialization; }
 
-    public List<Long> getAgentIds() {
+    public Set<Long> getAgentIds() {
         return agentIds;
     }
 
-    public void setAgentIds(List<Long> agentIds) {
+    public void setAgentIds(Set<Long> agentIds) {
         this.agentIds = agentIds;
     }
 

--- a/Secret-agency-api/src/main/java/cz/fi/muni/pa165/secretagency/dto/MissionDTO.java
+++ b/Secret-agency-api/src/main/java/cz/fi/muni/pa165/secretagency/dto/MissionDTO.java
@@ -19,8 +19,8 @@ public class MissionDTO {
     private MissionTypeEnum missionType;
     private LocalDate started;
     private LocalDate ended;
-    private Set<AgentDTO> agents = new HashSet<>();
-    private Set<ReportDTO> reports = new HashSet<>();
+    private Set<Long> agentIds = new HashSet<>();
+    private Set<Long> reportIds = new HashSet<>();
 
     public Long getId() {
         return id;
@@ -70,20 +70,20 @@ public class MissionDTO {
         this.ended = ended;
     }
 
-    public Set<AgentDTO> getAgents() {
-        return agents;
+    public Set<Long> getAgentIds() {
+        return agentIds;
     }
 
-    public void setAgents(Set<AgentDTO> agents) {
-        this.agents = agents;
+    public void setAgentIds(Set<Long> agentIds) {
+        this.agentIds = agentIds;
     }
 
-    public Set<ReportDTO> getReports() {
-        return reports;
+    public Set<Long> getReportIds() {
+        return reportIds;
     }
 
-    public void setReports(Set<ReportDTO> reports) {
-        this.reports = reports;
+    public void setReportIds(Set<Long> reportIds) {
+        this.reportIds = reportIds;
     }
 
     @Override
@@ -112,8 +112,8 @@ public class MissionDTO {
                 ", missionType=" + missionType +
                 ", started=" + started +
                 ", ended=" + ended +
-                ", agents=" + agents +
-                ", reports=" + reports +
+                ", agentIds=" + agentIds +
+                ", reportIds=" + reportIds +
                 '}';
     }
 }

--- a/Secret-agency-persistence/src/main/java/cz/fi/muni/pa165/secretagency/entity/Agent.java
+++ b/Secret-agency-persistence/src/main/java/cz/fi/muni/pa165/secretagency/entity/Agent.java
@@ -15,7 +15,7 @@ import java.util.*;
  */
 @SuppressWarnings("JpaDataSourceORMInspection")
 @Entity
-public class Agent {
+public class Agent implements Identifiable<Long> {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/Secret-agency-persistence/src/main/java/cz/fi/muni/pa165/secretagency/entity/Department.java
+++ b/Secret-agency-persistence/src/main/java/cz/fi/muni/pa165/secretagency/entity/Department.java
@@ -16,7 +16,7 @@ import java.util.Objects;
  * @author Milos Silhar (433614)
  */
 @Entity
-public class Department {
+public class Department implements Identifiable<Long> {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/Secret-agency-persistence/src/main/java/cz/fi/muni/pa165/secretagency/entity/Identifiable.java
+++ b/Secret-agency-persistence/src/main/java/cz/fi/muni/pa165/secretagency/entity/Identifiable.java
@@ -1,0 +1,5 @@
+package cz.fi.muni.pa165.secretagency.entity;
+
+public interface Identifiable<T> {
+    T getId();
+}

--- a/Secret-agency-persistence/src/main/java/cz/fi/muni/pa165/secretagency/entity/Mission.java
+++ b/Secret-agency-persistence/src/main/java/cz/fi/muni/pa165/secretagency/entity/Mission.java
@@ -17,7 +17,7 @@ import java.util.Set;
  * @author Adam Skurla (487588)
  */
 @Entity
-public class Mission {
+public class Mission implements Identifiable<Long> {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/Secret-agency-persistence/src/main/java/cz/fi/muni/pa165/secretagency/entity/Report.java
+++ b/Secret-agency-persistence/src/main/java/cz/fi/muni/pa165/secretagency/entity/Report.java
@@ -16,7 +16,7 @@ import java.util.Objects;
  */
 @SuppressWarnings("JpaDataSourceORMInspection")
 @Entity
-public class Report {
+public class Report implements Identifiable<Long> {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/Secret-agency-service/src/main/java/cz/fi/muni/pa165/secretagency/service/config/ServiceConfiguration.java
+++ b/Secret-agency-service/src/main/java/cz/fi/muni/pa165/secretagency/service/config/ServiceConfiguration.java
@@ -13,7 +13,8 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
-import java.util.List;
+import java.util.Collection;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -30,9 +31,9 @@ public class ServiceConfiguration {
         modelMapper.getConfiguration().setMatchingStrategy(MatchingStrategies.STANDARD);
 
         // convert nested collection of other DTOs to collection of their ids
-        Converter<List<Agent>, List<Long>> agentConvertor = createConvertor();
-        Converter<List<Mission>, List<Long>> missionConvertor = createConvertor();
-        Converter<List<Report>, List<Long>> reportConvertor = createConvertor();
+        Converter<Collection<Agent>, Set<Long>> agentConvertor = createConvertor();
+        Converter<Collection<Mission>, Set<Long>> missionConvertor = createConvertor();
+        Converter<Collection<Report>, Set<Long>> reportConvertor = createConvertor();
 
         // mapping from Department -> DepartmentDTO
         modelMapper.createTypeMap(Department.class, DepartmentDTO.class)
@@ -56,15 +57,15 @@ public class ServiceConfiguration {
 
     /**
      * Creates convertor for mapping entities to DTOs. If entity has attribute, which is collection of other
-     *   entities, it gets converted to collection of ids of those entities. The reason is to avoid circular
+     *   entities, it gets converted to set of ids of those entities. The reason is to avoid circular
      *   dependencies between DTOs.
      * @param <T> entity, which is converted
      * @return convertor
      */
-    private <T extends Identifiable<Long>> Converter<List<T>, List<Long>> createConvertor() {
+    private <T extends Identifiable<Long>> Converter<Collection<T>, Set<Long>> createConvertor() {
         @SuppressWarnings("Convert2MethodRef")
-        Converter<List<T>, List<Long>> converter = mappingContext -> mappingContext.getSource().stream()
-                .map(t -> t.getId()).collect(Collectors.toList());
+        Converter<Collection<T>, Set<Long>> converter = mappingContext -> mappingContext.getSource().stream()
+                .map(t -> t.getId()).collect(Collectors.toSet());
         return converter;
     }
 }

--- a/Secret-agency-service/src/main/java/cz/fi/muni/pa165/secretagency/service/config/ServiceConfiguration.java
+++ b/Secret-agency-service/src/main/java/cz/fi/muni/pa165/secretagency/service/config/ServiceConfiguration.java
@@ -1,6 +1,11 @@
 package cz.fi.muni.pa165.secretagency.service.config;
 
 import cz.fi.muni.pa165.secretagency.SecretAgencyPersistenceApplicationContext;
+import cz.fi.muni.pa165.secretagency.dto.AgentDTO;
+import cz.fi.muni.pa165.secretagency.dto.DepartmentDTO;
+import cz.fi.muni.pa165.secretagency.dto.MissionDTO;
+import cz.fi.muni.pa165.secretagency.entity.*;
+import org.modelmapper.Converter;
 import org.modelmapper.ModelMapper;
 import org.modelmapper.convention.MatchingStrategies;
 import org.springframework.context.annotation.Bean;
@@ -8,10 +13,11 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 /**
- * Author: Adam Kral <433328>
- * Date: 11/19/18
- * Time: 2:59 PM
+ * Author: Adam Kral <433328>, Jan Pavlu (487548)
  */
 @Configuration
 @Import(SecretAgencyPersistenceApplicationContext.class)
@@ -21,8 +27,44 @@ public class ServiceConfiguration {
     @Bean
     public ModelMapper modelMapper() {
         ModelMapper modelMapper = new ModelMapper();
-        // with loose mapping, mapper is able to map nested classes
         modelMapper.getConfiguration().setMatchingStrategy(MatchingStrategies.STANDARD);
+
+        // convert nested collection of other DTOs to collection of their ids
+        Converter<List<Agent>, List<Long>> agentConvertor = createConvertor();
+        Converter<List<Mission>, List<Long>> missionConvertor = createConvertor();
+        Converter<List<Report>, List<Long>> reportConvertor = createConvertor();
+
+        // mapping from Department -> DepartmentDTO
+        modelMapper.createTypeMap(Department.class, DepartmentDTO.class)
+                .addMappings(mapper -> mapper.using(agentConvertor).map(Department::getAgents,
+                                                                        DepartmentDTO::setAgentIds));
+
+        // mapping from Agent -> AgentDTO
+        modelMapper.createTypeMap(Agent.class, AgentDTO.class)
+                .addMappings(mapper -> mapper.using(missionConvertor).map(Agent::getMissions,
+                        AgentDTO::setMissionIds))
+                .addMappings(mapper -> mapper.using(reportConvertor).map(Agent::getReports,
+                                                                         AgentDTO::setReportIds));
+        // mapping from Mission -> MissionDTO
+        modelMapper.createTypeMap(Mission.class, MissionDTO.class)
+                .addMappings(mapper -> mapper.using(agentConvertor).map(Mission::getAgents,
+                                                                        MissionDTO::setAgentIds))
+                .addMappings(mapper -> mapper.using(reportConvertor).map(Mission::getReports,
+                                                                         MissionDTO::setReportIds));
         return modelMapper;
+    }
+
+    /**
+     * Creates convertor for mapping entities to DTOs. If entity has attribute, which is collection of other
+     *   entities, it gets converted to collection of ids of those entities. The reason is to avoid circular
+     *   dependencies between DTOs.
+     * @param <T> entity, which is converted
+     * @return convertor
+     */
+    private <T extends Identifiable<Long>> Converter<List<T>, List<Long>> createConvertor() {
+        @SuppressWarnings("Convert2MethodRef")
+        Converter<List<T>, List<Long>> converter = mappingContext -> mappingContext.getSource().stream()
+                .map(t -> t.getId()).collect(Collectors.toList());
+        return converter;
     }
 }

--- a/Secret-agency-service/src/test/java/cz/fi/muni/pa165/secretagency/service/BeanMappingServiceTest.java
+++ b/Secret-agency-service/src/test/java/cz/fi/muni/pa165/secretagency/service/BeanMappingServiceTest.java
@@ -1,23 +1,11 @@
 package cz.fi.muni.pa165.secretagency.service;
 
-import cz.fi.muni.pa165.secretagency.dto.AgentCreateDTO;
-import cz.fi.muni.pa165.secretagency.dto.AgentDTO;
-import cz.fi.muni.pa165.secretagency.dto.DepartmentCreateDTO;
-import cz.fi.muni.pa165.secretagency.dto.DepartmentDTO;
-import cz.fi.muni.pa165.secretagency.dto.MissionCreateDTO;
-import cz.fi.muni.pa165.secretagency.dto.MissionDTO;
-import cz.fi.muni.pa165.secretagency.dto.ReportCreateDTO;
-import cz.fi.muni.pa165.secretagency.dto.ReportDTO;
+import cz.fi.muni.pa165.secretagency.dto.*;
 import cz.fi.muni.pa165.secretagency.entity.Agent;
 import cz.fi.muni.pa165.secretagency.entity.Department;
 import cz.fi.muni.pa165.secretagency.entity.Mission;
 import cz.fi.muni.pa165.secretagency.entity.Report;
-import cz.fi.muni.pa165.secretagency.enums.AgentRankEnum;
-import cz.fi.muni.pa165.secretagency.enums.DepartmentSpecialization;
-import cz.fi.muni.pa165.secretagency.enums.LanguageEnum;
-import cz.fi.muni.pa165.secretagency.enums.MissionResultReportEnum;
-import cz.fi.muni.pa165.secretagency.enums.MissionTypeEnum;
-import cz.fi.muni.pa165.secretagency.enums.ReportStatus;
+import cz.fi.muni.pa165.secretagency.enums.*;
 import cz.fi.muni.pa165.secretagency.service.config.ServiceConfiguration;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.annotation.DirtiesContext;

--- a/Secret-agency-service/src/test/java/cz/fi/muni/pa165/secretagency/service/BeanMappingServiceTest.java
+++ b/Secret-agency-service/src/test/java/cz/fi/muni/pa165/secretagency/service/BeanMappingServiceTest.java
@@ -108,7 +108,7 @@ public class BeanMappingServiceTest extends AbstractTestNGSpringContextTests
     @Test
     public void mapDepartmentToDepartmentDtoTest() {
         Department department = new Department();
-        department.setId(1l);
+        department.setId(1L);
         department.setCity("london");
         department.setCountry("uk");
         department.setLatitude(2.0);
@@ -118,7 +118,7 @@ public class BeanMappingServiceTest extends AbstractTestNGSpringContextTests
         DepartmentDTO departmentDTO = beanMappingService.mapTo(department, DepartmentDTO.class);
 
         Assert.assertEquals(department.getId(), departmentDTO.getId());
-        Assert.assertEquals(department.getAgents().size(), departmentDTO.getAgents().size());
+        Assert.assertEquals(department.getAgents().size(), departmentDTO.getAgentIds().size());
         Assert.assertEquals(department.getCity(), departmentDTO.getCity());
         Assert.assertEquals(department.getCountry(), departmentDTO.getCountry());
         Assert.assertEquals(department.getLatitude(), departmentDTO.getLatitude());
@@ -129,7 +129,7 @@ public class BeanMappingServiceTest extends AbstractTestNGSpringContextTests
     @Test
     public void mapDepartmentDtoToDepartmentTest() {
         DepartmentDTO departmentDTO = new DepartmentDTO();
-        departmentDTO.setId(1l);
+        departmentDTO.setId(1L);
         departmentDTO.setCity("london");
         departmentDTO.setCountry("uk");
         departmentDTO.setLatitude(2.0);
@@ -139,7 +139,7 @@ public class BeanMappingServiceTest extends AbstractTestNGSpringContextTests
         Department department = beanMappingService.mapTo(departmentDTO, Department.class);
 
         Assert.assertEquals(department.getId(), departmentDTO.getId());
-        Assert.assertEquals(department.getAgents().size(), departmentDTO.getAgents().size());
+        Assert.assertEquals(department.getAgents().size(), departmentDTO.getAgentIds().size());
         Assert.assertEquals(department.getCity(), departmentDTO.getCity());
         Assert.assertEquals(department.getCountry(), departmentDTO.getCountry());
         Assert.assertEquals(department.getLatitude(), departmentDTO.getLatitude());
@@ -150,7 +150,7 @@ public class BeanMappingServiceTest extends AbstractTestNGSpringContextTests
    @Test
    public void mapAgentToAgentDtoTest() {
         Agent agent = new Agent();
-        agent.setId(1l);
+        agent.setId(1L);
         agent.setName("bond");
         agent.setLanguages(Collections.singleton(LanguageEnum.EN));
         agent.setCodeName("007");
@@ -170,7 +170,7 @@ public class BeanMappingServiceTest extends AbstractTestNGSpringContextTests
     @Test
     public void mapAgentDtoToAgentTest() {
         AgentDTO agentDTO = new AgentDTO();
-        agentDTO.setId(1l);
+        agentDTO.setId(1L);
         agentDTO.setName("bond");
         agentDTO.setLanguages(Collections.singleton(LanguageEnum.EN));
         agentDTO.setCodeName("007");
@@ -190,7 +190,7 @@ public class BeanMappingServiceTest extends AbstractTestNGSpringContextTests
     @Test
     public void mapReportToReportDtoTest() {
         Report report = new Report();
-        report.setId(42l);
+        report.setId(42L);
         report.setText("report");
         report.setReportStatus(ReportStatus.APPROVED);
         report.setMissionResult(MissionResultReportEnum.COMPLETED);
@@ -208,7 +208,7 @@ public class BeanMappingServiceTest extends AbstractTestNGSpringContextTests
     @Test
     public void mapReportDtoToReportTest() {
         ReportDTO reportDTO = new ReportDTO();
-        reportDTO.setId(42l);
+        reportDTO.setId(42L);
         reportDTO.setText("report");
         reportDTO.setReportStatus(ReportStatus.APPROVED);
         reportDTO.setMissionResult(MissionResultReportEnum.COMPLETED);
@@ -226,7 +226,7 @@ public class BeanMappingServiceTest extends AbstractTestNGSpringContextTests
     @Test
     public void mapMissionToMissionDtoTest() {
         Mission mission = new Mission();
-        mission.setId(142l);
+        mission.setId(142L);
         mission.setLatitude(3.4);
         mission.setLongitude(54.1);
         mission.setStarted(LocalDate.of(2013, 4, 9));
@@ -246,7 +246,7 @@ public class BeanMappingServiceTest extends AbstractTestNGSpringContextTests
     @Test
     public void mapMissionDtoToMissionTest() {
         MissionDTO missionDTO = new MissionDTO();
-        missionDTO.setId(142l);
+        missionDTO.setId(142L);
         missionDTO.setLatitude(3.4);
         missionDTO.setLongitude(54.1);
         missionDTO.setStarted(LocalDate.of(2013, 4, 9));


### PR DESCRIPTION
Při mapování entit na DTO nám došlo k zacyklení, protože na sebe DTO vzájemně odkazují. Předělal jsem mapování tak, aby se atributy DTO, které jsou kolekcí DTO, mapovaly na kolekci ID.
Po téhle úpravě k zacyklední nedojde.

Možná nevýhoda je, že mapování nefunguje opačně. Tzn. že atributy, které jsou kolekcí id DTO, nenamapuji na kolekci entit. Musel bych při mapování šahat do databáze a nevím, jestli to někdy v budoucnu bude potřeba. Pokud jo, tak bych to přidal.